### PR TITLE
Updated for clang changes for give an comp macros.

### DIFF
--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -722,7 +722,11 @@ KiSystemCallTrampoline(IN PVOID Handler,
         : "c"(StackBytes),
           "d"(Arguments),
           "r"(Handler)
+        #if defined(__clang__)
         : "%esi", "%edi"
+        #elif defined(__GNUC__)
+        : "%esp", "%esi", "%edi"
+        #endif
     );
     return Result;
 }

--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -722,7 +722,7 @@ KiSystemCallTrampoline(IN PVOID Handler,
         : "c"(StackBytes),
           "d"(Arguments),
           "r"(Handler)
-        : "%esp", "%esi", "%edi"
+        : "%esi", "%edi"
     );
     return Result;
 }


### PR DESCRIPTION
These are predefined macros that compilers used:
```
Visual Studio       _MSC_VER
gcc                 __GNUC__
clang               __clang__
emscripten          __EMSCRIPTEN__ (for asm.js and webassembly)
MinGW 32            __MINGW32__
MinGW-w64 32bit     __MINGW32__
MinGW-w64 64bit     __MINGW64__
```

So if you want to adapt some sort of codes for clang and gcc, and they have different approach for some sort of things use macros, use `defined()` function then add them without deleting any sort of working code. It makes code more clean and buildable for any reason.
